### PR TITLE
fix: Update JSON Annotations Linter Errors

### DIFF
--- a/04-webdev/01-json/README.md
+++ b/04-webdev/01-json/README.md
@@ -201,8 +201,8 @@ func main() {
   aBoolean, _ := json.Marshal(true)
   aString, _ := json.Marshal("a string")
   person := Person{
-    Id: 1
-    Name: "a person"
+    Id: 1,
+    Name: "a person",
   }
   aPerson, _ := json.Marshal(&person)
   fmt.Println(string(aBoolean)) // true

--- a/04-webdev/01-json/README.md
+++ b/04-webdev/01-json/README.md
@@ -119,7 +119,7 @@ We will use the `Unmarshal()` function and provide it with the string literal as
 ```go
 package main
 
-imports (
+import (
   "fmt"
   "encoding/json"
 )

--- a/04-webdev/01-json/README.md
+++ b/04-webdev/01-json/README.md
@@ -81,19 +81,19 @@ So that means, we need to add the following annotations to our above created str
 
 ```go
 type Product struct {
-  Id int `json: "id"`
-  Name string `json: "name"`
+  Id int `json:"id"`
+  Name string `json:"name"`
 }
 
 type Response struct {
-  Products []Product `json: "products"`
+  Products []Product `json:"products"`
 }
 ```
 
 What these annotations do is to say, in the JSON data, look for properties with these names and map them to the following property. Like in this example from above:
 
 ```go
-Id int `json: "id"`
+Id int `json:"id"`
 ```
 
 ### Reading the data
@@ -151,12 +151,12 @@ import (
 )
 
 type Products struct {
- Products []Product `json: products`
+ Products []Product `json:"products"`
 }
 
 type Product struct {
- Id   int    `json: "id"`
- Name string `json: "name"`
+ Id   int    `json:"id"`
+ Name string `json:"name"`
 }
 
 func main(){
@@ -193,8 +193,8 @@ import (
 )
 
 type Person struct {
-  Id int `json: "id"`
-  Name string`json: "name"`
+  Id int `json:"id"`
+  Name string`json:"name"`
 }
 
 func main() {
@@ -248,18 +248,18 @@ import (
 )
 
 type OrderItem struct {
- Id       int     `json: "id"`
- Quantity int     `json: "quantity"`
- Total    float32 `json: "total"`
+ Id       int     `json:"id"`
+ Quantity int     `json:"quantity"`
+ Total    float32 `json:"total"`
 }
 
 type Order struct {
- Id    int         `json: "id"`
- Items []OrderItem `json: items`
+ Id    int         `json:"id"`
+ Items []OrderItem `json:"items"`
 }
 
 type Response struct {
- Orders []Order `json: orders`
+ Orders []Order `json:"orders"`
 }
 
 func main() {

--- a/04-webdev/01-json/main.go
+++ b/04-webdev/01-json/main.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Person struct {
-	Name string `json: "name"`
-	Age  int    `json: "age"`
+	Name string `json:"name"`
+	Age  int    `json:"age"`
 }
 
 func main() {

--- a/04-webdev/01-json/orders.go
+++ b/04-webdev/01-json/orders.go
@@ -7,18 +7,18 @@ import (
 )
 
 type OrderItem struct {
-	Id       int     `json: "id"`
-	Quantity int     `json: "quantity"`
-	Total    float32 `json: "total"`
+	Id       int     `json:"id"`
+	Quantity int     `json:"quantity"`
+	Total    float32 `json:"total"`
 }
 
 type Order struct {
-	Id    int         `json: "id"`
-	Items []OrderItem `json: items`
+	Id    int         `json:"id"`
+	Items []OrderItem `json:"items"`
 }
 
 type Response struct {
-	Orders []Order `json: orders`
+	Orders []Order `json:"orders"`
 }
 
 func main() {


### PR DESCRIPTION
This pull request adjusts the "Working with JSON" lesson and updates JSON annotations to remove linter errors.

I understand the white space is considered optional, but when doing this lesson I was getting linter errors which were resolved by removing said optional whitespace. I think making sure the lesson follows the provided linter ideal for best practice purposes, especially as this resource is aimed at Go beginners.